### PR TITLE
feat: add honeypot anti-bot field to registration form and backend

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -104,6 +104,12 @@ def register():
     if not data:
         return jsonify({"error": "No data provided"}), 400
 
+    # Honeypot check: if 'username' field is filled, likely a bot
+    if data.get("username"):
+        current_app.logger.warning(f"Honeypot triggered on registration: username={data.get('username')}")
+        # Optionally, you can return a generic error or silently drop
+        return jsonify({"error": "Registration failed. Please try again."}), 400
+
     # Check if user already exists
     if User.query.filter_by(email=data["email"]).first():
         return jsonify({"error": "Email already exists"}), 400

--- a/frontend/src/components/Auth/Register.jsx
+++ b/frontend/src/components/Auth/Register.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Box, TextField, Button, Typography, CircularProgress, Alert, Link, Divider } from '@mui/material';
 import axiosInstance from '../../api/axiosInstance';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
@@ -11,6 +11,7 @@ function Register({ setIsLoggedIn }) {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const usernameRef = useRef();
   const navigate = useNavigate();
 
   const handleSubmit = async (event) => {
@@ -31,6 +32,9 @@ function Register({ setIsLoggedIn }) {
       return;
     }
 
+    // Get honeypot value
+    const honeypot = usernameRef.current ? usernameRef.current.value : '';
+
     try {
       const response = await axiosInstance({
         method: 'post',
@@ -38,6 +42,7 @@ function Register({ setIsLoggedIn }) {
         data: {
           email,
           password,
+          username: honeypot, // honeypot field
         },
         headers: {
           'Content-Type': 'application/json',
@@ -122,6 +127,23 @@ function Register({ setIsLoggedIn }) {
         Register
       </Typography>
       <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1, width: '100%', maxWidth: '400px' }}>
+        {/* Honeypot field: visually hidden from users */}
+        <input
+          type="text"
+          name="username"
+          tabIndex="-1"
+          autoComplete="off"
+          ref={usernameRef}
+          style={{
+            position: 'absolute',
+            left: '-9999px',
+            width: '1px',
+            height: '1px',
+            opacity: 0,
+            pointerEvents: 'none',
+          }}
+          aria-hidden="true"
+        />
         <TextField
           margin="normal"
           required
@@ -200,4 +222,4 @@ function Register({ setIsLoggedIn }) {
   );
 }
 
-export default Register; 
+export default Register;


### PR DESCRIPTION
Added a visually hidden honeypot field ('username') to the React registration form to trap bots.
Backend registration endpoint now checks for the honeypot field and rejects registrations if it is filled.
Helps prevent automated spam registrations without impacting legitimate users.